### PR TITLE
Compatibility Update and Master Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.zip
 *.b#*
 *.s#*
+.DS_Store


### PR DESCRIPTION
Release Notes:

* Fixed fader ordering difference between original version and new prototype
* Optimized the range that the faders cover for the i2c integration
* Optimized the noise reduction from the ADCs
* Added Master Mode flag to turn on support for direct control of up to 4 TXo, 4 Ansible, and 16 ER-301 channels