### PR TITLE
Rename MIDI device to '16n'.

### DIFF
--- a/firmware/_16n_faderbank_firmware/usb_name.c
+++ b/firmware/_16n_faderbank_firmware/usb_name.c
@@ -1,0 +1,10 @@
+#include <usb_names.h>
+
+#define PRODUCT_NAME    {'1','6','n'}
+#define PRODUCT_NAME_LEN 3
+
+struct usb_string_descriptor_struct usb_string_product_name = {
+        2 + PRODUCT_NAME_LEN * 2,
+        3,
+        PRODUCT_NAME
+};


### PR DESCRIPTION
## What

Make the 16n show up in your MIDI devices as "16n" rather than "Teensy MIDI"

## Why

Easier to find it if you have multiple homebrew Teensy devices; makes it all feel a bit more professional.

Note that if you've already connected the 16n as _Teensy MIDI_, for a Mac to detect this change you'll need to:

* disconnect the 16n physically
* go to "Audio/MIDI preferences
* find the "Teensy MIDI" device and click 'remove'.

Then, next time you connect 16n, it'll appear in your MIDI devices as '16n'.